### PR TITLE
NoiseRouterMixin: remove the 1.5 multiplier from formulaValue

### DIFF
--- a/common/src/main/java/me/adda/terramath/mixin/NoiseRouterMixin.java
+++ b/common/src/main/java/me/adda/terramath/mixin/NoiseRouterMixin.java
@@ -36,7 +36,7 @@ public class NoiseRouterMixin {
                     double formulaValue = formula.evaluate(x, y, z);
 
                     if (!settings.isUseDensityMode()) {
-                        double targetHeight = 64 / scale + (formulaValue * 1.5);
+                        double targetHeight = 64 / scale + formulaValue;
                         return y < targetHeight ? 1.0 : -1.0;
                     } else {
                         double targetHeight = settings.getBaseHeight() / scale +


### PR DESCRIPTION
Remove the 1.5 multiplier from formulaValue if not using advanced mode.

Right now, if not ticking Advanced Mode, the world is stretched by x1.5 in the y axis (very evident with a formula like `x`. In my opinion, this feels better and it is always possible to multiply everything by a value in the formula Field if a height stretch is desired.