### PR TITLE
[Suggestion] WorldTabMixin: Increase max Formula Length to 32768

### DIFF
--- a/common/src/main/java/me/adda/terramath/mixin/WorldTabMixin.java
+++ b/common/src/main/java/me/adda/terramath/mixin/WorldTabMixin.java
@@ -84,7 +84,7 @@ public abstract class WorldTabMixin extends GridLayoutTab {
                 }
             };
 
-            this.formulaField.setMaxLength(128);
+            this.formulaField.setMaxLength(32768);
             this.formulaField.setValue("");
             this.formulaField.setTextColor(0xFFFFFF);
             this.formulaField.setTextColorUneditable(0x808080);


### PR DESCRIPTION
A downside mentioned in AsianHalfSquats Video and in a comment is that you can only put 128 characters into the formula input. I suggest raising it to basically unlimited with this PR. I know that very long Formulas slow down generation time tremendously, but I think it has more advantages to allow players to use longer formulas. Maybe a warning about generation times can be added in the future.