### PR TITLE
Add noise(x,y,z) function using org.joml.SimplexNoise

### DIFF
--- a/common/src/main/java/me/adda/terramath/math/FormulaParser.java
+++ b/common/src/main/java/me/adda/terramath/math/FormulaParser.java
@@ -42,7 +42,9 @@ public class FormulaParser {
             "abs", "exp", "floor", "ceil", "round", "sign",
 
             "gamma", "erf", "beta", "mod",
-            "max", "min", "sigmoid", "clamp"
+            "max", "min", "sigmoid", "clamp",
+
+            "noise"
     ));
 
     public static final Map<Character, Integer> OPERATOR_PRECEDENCE = new ConcurrentHashMap<>();

--- a/common/src/main/java/me/adda/terramath/math/MathExtensions.java
+++ b/common/src/main/java/me/adda/terramath/math/MathExtensions.java
@@ -1,5 +1,7 @@
 package me.adda.terramath.math;
 
+import org.joml.SimplexNoise;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -70,5 +72,9 @@ public class MathExtensions {
                 (c[4] + t * (c[5] + t * (c[6] + t * (c[7] + t * (c[8] + t * c[9])))))))));
 
         return x >= 0 ? 1.0 - tau : tau - 1.0;
+    }
+
+    public static double noise(double x, double y, double z) {
+        return SimplexNoise.noise((float) x, (float) y, (float) z);
     }
 }

--- a/common/src/main/java/me/adda/terramath/math/ParsedFormula.java
+++ b/common/src/main/java/me/adda/terramath/math/ParsedFormula.java
@@ -153,6 +153,8 @@ public class ParsedFormula {
                 case "sigmoid" -> 1.0 / (1.0 + Math.exp(-args.get(0)));
                 case "clamp" -> Math.min(Math.max(args.get(0), args.get(1)), args.get(2));
 
+                case "noise" -> MathExtensions.noise(args.get(0), args.get(1), args.get(2));
+
                 default -> throw new FormulaException(FormulaParser.ERROR_UNKNOWN_FUNCTION, name);
             };
         }
@@ -325,7 +327,7 @@ public class ParsedFormula {
         private void validateFunctionArguments(String name, List<ExpressionNode> args) {
             int expectedArgs = switch (name) {
                 case "pow", "mod", "max", "min", "beta" -> 2;
-                case "clamp" -> 3;
+                case "clamp", "noise" -> 3;
                 default -> 1;
             };
 


### PR DESCRIPTION
This is an attempt for #1, it adds a Noise function to add variation to the world. I tested it with `noise(x/30,y/30,z/30)*15` and it looks like this:

![grafik](https://github.com/user-attachments/assets/fa8d8dfe-9470-4a82-818b-2b13901726f4)
![2025-02-09_10 30 20](https://github.com/user-attachments/assets/130115c3-0cc9-4960-bbd3-7ec3b2965eef)

I didn't find out how to use a generator from Minecraft itself. It would have the advantages of 64-bit floats maybe, and having it bound to the world seed.